### PR TITLE
fix: bumping caddy version to fix CVE CS-913

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} docker.io/caddy:builder-alpine AS 
 # see:
 # - https://github.com/caddyserver/caddy/releases
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-      xcaddy build v2.7.0-beta.2
+      xcaddy build v2.10.2
 
 ### final image
 FROM --platform=${BUILDPLATFORM:-linux/amd64} docker.io/alpine


### PR DESCRIPTION
CVE details: https://github.com/advisories/GHSA-mrww-27vc-gghv